### PR TITLE
Fix authorization link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To locally host, follow these steps:
 `python3 bot.py`
 
 ## Invite
-AutoTSS can be invited into any Discord server using [this](https://discord.com/oauth2/authorize?client_id=804072225723383818&scope=bot&permissions=93184/) link.
+AutoTSS can be invited into any Discord server using [this](https://discord.com/oauth2/authorize?client_id=804072225723383818&scope=bot&permissions=93184) link.
 
 ## Support
 For any questions/issues you have, join my [discord](https://discord.gg/fAngssA/).


### PR DESCRIPTION
The extra slash caused it not to grant the bot any permissions.